### PR TITLE
New configuration bridge option for irc bot special character

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -364,11 +364,12 @@ export default class Bridge extends EventEmitter {
 
         let scape_char = this._options.ircScapeCharacter;
 
-        if (scape_char && message.startsWith(scape_char)){
-            this._ircChannel.sendMessage(message);
-        } else if (this._options.oneConnectionByUser) {
+        if (this._options.oneConnectionByUser) {
             let chan = this._getIrcUserChan(user.username);
             chan.sendMessage(message);
+        } else if (scape_char && message.startsWith(scape_char)){
+            this._ircChannel.sendMessage(message);
+
         } else {
             let msg = `[Telegram/@${user.username}] ${message}`;
             this._ircChannel.sendMessage(msg);

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -25,6 +25,7 @@ export const defaultConfig = {
     oneConnectionByUser: false,
     prefix: "telegram_",
     suffix: "",
+    ircScapeCharacter: "",
 };
 
 let userInstances = [];
@@ -360,7 +361,12 @@ export default class Bridge extends EventEmitter {
      */
     _handleTelegramMessage(user, message) {
         debug("telegram in message", user);
-        if (this._options.oneConnectionByUser) {
+
+        let scape_char = this._options.ircScapeCharacter;
+
+        if (scape_char && message.startsWith(scape_char)){
+            this._ircChannel.sendMessage(message);
+        } else if (this._options.oneConnectionByUser) {
             let chan = this._getIrcUserChan(user.username);
             chan.sendMessage(message);
         } else {

--- a/src/cli/config.js
+++ b/src/cli/config.js
@@ -56,6 +56,7 @@ const generateConfigQuestions = function (defaults = {}, options = {}) {
                             false :
                             config.get("irc:secure"),
         "oneConnectionByUser": config.get("oneConnectionByUser") || false,
+        "ircScapeCharacter": config.get("ircScapeCharacter") || "",
         "prefix": config.get("prefix") || "telegram_",
         "suffix": config.get("suffix") || "",
     }, defaults);
@@ -112,6 +113,12 @@ const generateConfigQuestions = function (defaults = {}, options = {}) {
             name: "oneConnectionByUser",
             message: "Do you use one new IRC connection by telgram user?",
             default: defaultsOptions["oneConnectionByUser"],
+        },
+        {
+            type: "input",
+            name: "ircScapeCharacter",
+            message: "Do you use one especial character for IRC bots?",
+            default: defaultsOptions["ircScapeCharacter"],
         },
         {
             type: "input",
@@ -337,6 +344,7 @@ const editBridge = function () {
                                 false :
                                 bconfig.get("irc:secure"),
             "oneConnectionByUser": bconfig.get("oneConnectionByUser"),
+            "ircScapeCharacter": bconfig.get("ircScapeCharacter"),
             "prefix": bconfig.get("prefix"),
             "suffix": bconfig.get("suffix"),
         };

--- a/src/config.js
+++ b/src/config.js
@@ -122,6 +122,7 @@ export const getBridgeConfig = function (name) {
         prefix: config.get("prefix"),
         suffix: config.get("suffix"), 
         oneConnectionByUser: config.get("oneConnectionByUser"),
+        ircScapeCharacter: config.get("ircScapeCharacter"),
     }, bridge);
 
     for (let i in bridge) {


### PR DESCRIPTION
This functionality allows you to configure a special character that can be used by the bot of the IRC channel itself.

In a nutshell, run the IRC bot command from the telegram.

Example - Written from Telegram (View from IRC):

```
23:10:19 < quilmeslug_bot> [Telegram/@yosoycarpediem] Test
23:10:25 < quilmeslug_bot> !help
23:10:25 < sQ`> !lasttweet !user !imdb !google !calc !dolar !pesos !quote !qadd !qdel !qlast !qsearch !karma !bitcoin !litecoin !clima !bofh !doge 
                !bash !subte !translate !imgur !rank
23:10:33 < quilmeslug_bot> !clima quilmes
23:10:34 < sQ`> Quilmes, Argentina: Mostly Cloudy, feels like: 9.7˚, min: 8˚, humidity: 90%
```